### PR TITLE
check for a blank caption line

### DIFF
--- a/lib/webvtt/file.rb
+++ b/lib/webvtt/file.rb
@@ -66,7 +66,9 @@ private
         cue_opts[:identifier] = collected_lines.first
         cue_opts[:cue_line] = collected_lines[1]
       end
-      cue_opts[:text] = collected_lines[2..-1].join("\n")
+      if collected_lines[2..-1]
+        cue_opts[:text] = collected_lines[2..-1].join("\n")
+      end
       cues << Cue.new(cue_opts)
     end
 


### PR DESCRIPTION
Sometimes the caption line is blank. This fix checks to see if the caption is there at all and if not it doesn't bail.